### PR TITLE
Update CopilotChat and Theme Configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "copilotchat": {
       "flake": false,
       "locked": {
-        "lastModified": 1710849460,
-        "narHash": "sha256-YRfe53MfqmRkgM2YgdYjps1FvhcDeqiSwuPe7YMIM7k=",
+        "lastModified": 1710900281,
+        "narHash": "sha256-Yx6xmw+I3mKTNRCJyTDkXsNGnl+Y0sisYu7kORc7iR4=",
         "owner": "CopilotC-Nvim",
         "repo": "CopilotChat.nvim",
-        "rev": "4811cdd91b35345358da89f0eedd1f2b92c8bf04",
+        "rev": "453b0d54533f6378a188a6afbc10ec087210cad8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,13 @@
 {
   description = "Neovim configuration for TheAltF4Stream as a plugin";
 
-  inputs.copilotchat.flake = false;
-  inputs.copilotchat.url = "github:CopilotC-Nvim/CopilotChat.nvim?ref=canary";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    copilotchat = {
+      flake = false;
+      url = "github:CopilotC-Nvim/CopilotChat.nvim?ref=canary";
+    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
 
   outputs = inputs @ {
     self,

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -145,6 +145,7 @@ in rec {
     plugins = mkNeovimPlugins {inherit system;};
   in {
     inherit extraConfig extraPackages plugins;
+    defaultEditor = true;
     enable = true;
     withNodeJs = true;
     withPython3 = true;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,7 +48,7 @@ in rec {
     vimPlugins.telescope-nvim
 
     # theme
-    vimPlugins.oxocarbon-nvim
+    vimPlugins.tokyonight-nvim
 
     # floaterm
     vimPlugins.vim-floaterm

--- a/lua/TheAltF4Stream/theme.lua
+++ b/lua/TheAltF4Stream/theme.lua
@@ -1,10 +1,10 @@
 local colorizer = require 'colorizer'
+local comment = require 'Comment'
 local gitsigns = require 'gitsigns'
 local lualine = require 'lualine'
 local noice = require 'noice'
 local notify = require 'notify'
-local oxocarbon = require('oxocarbon').oxocarbon
-local comment = require 'Comment'
+local tokyonight = require 'tokyonight'
 
 local function init()
     colorizer.setup {}
@@ -16,14 +16,14 @@ local function init()
     lualine.setup {
         options = {
             extensions = { "fzf", "quickfix" },
+            theme = 'tokyonight',
         },
     }
 
-    notify.setup {
-        background_colour = "#000000",
+    notify.setup({
         render = "wrapped-compact",
         timeout = 2500,
-    }
+    })
 
     noice.setup {
         lsp = {
@@ -41,26 +41,42 @@ local function init()
         },
     }
 
-    vim.opt.background = "dark"
-    vim.cmd.colorscheme "oxocarbon"
+    tokyonight.setup {
+        on_highlights = function(hl, c)
+            local prompt = "#2d3149"
+            hl.TelescopeNormal = {
+                bg = c.bg_dark,
+                fg = c.fg_dark,
+            }
+            hl.TelescopeBorder = {
+                bg = c.bg_dark,
+                fg = c.bg_dark,
+            }
+            hl.TelescopePromptNormal = {
+                bg = prompt,
+            }
+            hl.TelescopePromptBorder = {
+                bg = prompt,
+                fg = prompt,
+            }
+            hl.TelescopePromptTitle = {
+                bg = prompt,
+                fg = prompt,
+            }
+            hl.TelescopePreviewTitle = {
+                bg = c.bg_dark,
+                fg = c.bg_dark,
+            }
+            hl.TelescopeResultsTitle = {
+                bg = c.bg_dark,
+                fg = c.bg_dark,
+            }
+        end,
+        style = "night",
+        transparent = true,
+    }
 
-    --[[ Editor ]]
-    vim.api.nvim_set_hl(0, "Normal", { bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "NormalFloat", { bg = oxocarbon.none })
-
-    --[[ Telescope ]]
-    vim.api.nvim_set_hl(0, "TelescopeBorder", { fg = oxocarbon.base03, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopeMatching",
-        { fg = oxocarbon.base14, bg = oxocarbon.none, bold = true, italic = true })
-    vim.api.nvim_set_hl(0, "TelescopeNormal", { fg = oxocarbon.none, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopePreviewLine", { fg = oxocarbon.none, bg = oxocarbon.base01 })
-    vim.api.nvim_set_hl(0, "TelescopePreviewTitle", { fg = oxocarbon.base14, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopePromptBorder", { fg = oxocarbon.base03, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopePromptNormal", { fg = oxocarbon.base04, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopePromptPrefix", { fg = oxocarbon.base08, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopePromptTitle", { fg = oxocarbon.base14, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopeResultsTitle", { fg = oxocarbon.base14, bg = oxocarbon.none })
-    vim.api.nvim_set_hl(0, "TelescopeSelection", { fg = oxocarbon.none, bg = oxocarbon.base02 })
+    vim.cmd [[colorscheme tokyonight-night]]
 end
 
 return {


### PR DESCRIPTION
## Overview

- Update `CopilotChat.nvim` plugin to latest revision
- Change theme from `oxocarbon-nvim` to `tokyonight-nvim`
- Refactor `flake.nix` inputs structure for clarity
- Adjust theme configuration in `theme.lua` to support `tokyonight` settings
- Enable `defaultEditor` in `lib/default.nix` configuration