### PR TITLE
Add Gleam Support to Nix and Lua Config

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -94,6 +94,7 @@ in rec {
     ocamlPackages.ocaml-lsp
     ocamlPackages.ocamlformat
     pkgs.cuelsp
+    pkgs.gleam
     pkgs.gopls
     pkgs.haskell-language-server
     pkgs.jsonnet-language-server

--- a/lua/TheAltF4Stream/languages.lua
+++ b/lua/TheAltF4Stream/languages.lua
@@ -106,6 +106,7 @@ local function init()
             }
         },
         dockerls = {},
+        gleam = {},
         gopls = {
             settings = {
                 gopls = {


### PR DESCRIPTION
### Added
- `pkgs.gleam` to `lib/default.nix`
- `gleam` config to `lua/TheAltF4Stream/languages.lua`
