### PR TITLE
Update GitHub Actions and Dependencies

### DIFF
--- a/.github/workflows/flake.yaml
+++ b/.github/workflows/flake.yaml
@@ -6,21 +6,20 @@ on:
     branches:
       - main
 
+env:
+  CACHIX_BINARY_CACHE: altf4llc-os
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v25
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
       - run: nix develop -c just check
-      - run: nix develop -c just cache-inputs
-      - run: nix develop -c just cache-shell
 
   build:
     needs:
@@ -32,12 +31,10 @@ jobs:
           - default
           - neovim
     steps:
-      - uses: cachix/install-nix-action@v25
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
+          name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just cache-build "${{ matrix.profile }}"
+      - run: nix develop -c just build "${{ matrix.profile }}"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "copilotchat": {
       "flake": false,
       "locked": {
-        "lastModified": 1712910409,
-        "narHash": "sha256-1gl2xe5A62a9CfSNpB610Klg6PYEIGYBtg0Yqwqkx+I=",
+        "lastModified": 1712990755,
+        "narHash": "sha256-Nwugw3YDO4DDZeluepRY7d9F5umaGviuQ2EkrF6FNd4=",
         "owner": "CopilotC-Nvim",
         "repo": "CopilotChat.nvim",
-        "rev": "9e8b3513540653edad4a5433f0b3875bc307e738",
+        "rev": "9898b4cd1b19c6ca639b77b34bb599a119356c1f",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -1,18 +1,6 @@
 build profile:
     nix build --json --no-link --print-build-logs ".#{{ profile }}"
 
-cache-build profile cache_name="altf4llc-os":
-    just build "{{ profile }}" | jq -r '.[].outputs | to_entries[].value' | cachix push {{ cache_name }}
-
-cache-inputs cache_name="altf4llc-os":
-    nix flake archive --json \
-      | jq -r '.path,(.inputs|to_entries[].value.path)' \
-      | cachix push "{{ cache_name }}"
-
-cache-shell cache_name="altf4llc-os":
-    nix develop --profile "dev-profile" -c true
-    cachix push "{{ cache_name }}" "dev-profile"
-
 check:
     nix flake check
 

--- a/lua/TheAltF4Stream/chatgpt.lua
+++ b/lua/TheAltF4Stream/chatgpt.lua
@@ -5,8 +5,8 @@ local function init()
 
     chatgpt.setup({
         api_key_cmd = api_key_cmd,
-        openai_params = { model = "gpt-4-turbo-preview" },
-        openai_edit_params = { model = "gpt-4" }
+        openai_edit_params = { model = "gpt-4" },
+        openai_params = { model = "gpt-4" },
     })
 
     local options = { noremap = true, silent = true }


### PR DESCRIPTION
### Added
- `env` section for `CACHIX_BINARY_CACHE`

### Changed
- Updated `cachix/cachix-action` to `v14`
- Updated `actions/checkout` to `v4`
- Replaced `cachix/install-nix-action` with `DeterminateSystems/nix-installer-action@main`
- Updated `flake.lock` dependencies
- Modified `chatgpt.lua` configuration

### Removed
- `cache-build`, `cache-inputs`, and `cache-shell` from `justfile`
- `github_access_token` usage in GitHub Actions
