### PR TITLE
flake update broken aftert utillinux opt rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ These language servers provide support for various programming languages, offeri
 | `bash-language-server`              | [bash-language-server](https://github.com/bash-lsp/bash-language-server)                               |
 | `diagnostic-languageserver`         | [diagnostic-languageserver](https://github.com/iamcco/diagnostic-languageserver)                       |
 | `dockerfile-language-server-nodejs` | [dockerfile-language-server-nodejs](https://github.com/rcjsuen/dockerfile-language-server-nodejs)      |
-| `gopls`                             | [gopls](https://github.com/golang/tools/tree/master/gopls)                                             |
 | `jsonnet-language-server`           | [jsonnet-language-server](https://github.com/jdbaldry/jsonnet-language-server)                         |
 | `lua-language-server`               | [lua-language-server](https://github.com/sumneko/lua-language-server)                                  |
 | `nil`                               | [nil](https://github.com/oxalica/nil)                              |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Language plugins that provide enhancements such as syntax highlighting, LSP conf
 | `nvim-treesitter.withAllGrammars`  | [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) |
 | `rust-tools-nvim`                  | [rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim)        |
 | `vim-just`                         | [vim-just](https://github.com/NoahTheDuke/vim-just)                   |
-| `vim-nickel`                       | [vim-nickel](https://github.com/nickel-lang/vim-nickel)               |
 | `zig-vim`                          | [zig.vim](https://github.com/ziglang/zig.vim)                         |
 
 ### Navigation
@@ -171,7 +170,6 @@ return require('packer').startup(function(use)
   use {'nvim-treesitter/nvim-treesitter', run = ':TSUpdate'}
   use 'simrat39/rust-tools.nvim'
   use 'NoahTheDuke/vim-just'
-  use 'nickel-lang/vim-nickel'
   use 'ziglang/zig.vim'
 
   -- Navigation

--- a/README.md
+++ b/README.md
@@ -31,31 +31,16 @@ These language servers provide support for various programming languages, offeri
 | Dependency Name                     | Dependency URL                                                                                         |
 |-------------------------------------|--------------------------------------------------------------------------------------------------------|
 | `bash-language-server`              | [bash-language-server](https://github.com/bash-lsp/bash-language-server)                               |
-| `cuelsp`                            | [cuelsp](https://github.com/cuelang/cuelsp)                                                            |
-| `dhall-lsp-server`                  | [dhall-lsp-server](https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server)           |
 | `diagnostic-languageserver`         | [diagnostic-languageserver](https://github.com/iamcco/diagnostic-languageserver)                       |
 | `dockerfile-language-server-nodejs` | [dockerfile-language-server-nodejs](https://github.com/rcjsuen/dockerfile-language-server-nodejs)      |
-| `dune`                              | [dune](https://github.com/ocaml/dune)                                                                  |
-| `gleam`                             | [gleam](https://github.com/gleam-lang/gleam)                                                           |
 | `gopls`                             | [gopls](https://github.com/golang/tools/tree/master/gopls)                                             |
-| `haskell-language-server`           | [haskell-language-server](https://github.com/haskell/haskell-language-server)                          |
 | `jsonnet-language-server`           | [jsonnet-language-server](https://github.com/jdbaldry/jsonnet-language-server)                         |
 | `lua-language-server`               | [lua-language-server](https://github.com/sumneko/lua-language-server)                                  |
-| `nil`                               | [nil](https://github.com/NixOS/nixtree/master/development/tools/misc/nil)                              |
-| `nls`                               | [nls](https://github.com/nix-community/nix-lsp)                                                        |
-| `ocaml-lsp`                         | [ocaml-lsp](https://github.com/ocaml/ocaml-lsp)                                                        |
-| `ocamlformat`                       | [ocamlformat](https://github.com/ocaml-ppx/ocamlformat)                                                |
-| `omnisharp-roslyn`                  | [omnisharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn)                                      |
-| `postgres-lsp`                      | [postgres-lsp](https://github.com/darold/postgresql-lsp)                                               |
+| `nil`                               | [nil](https://github.com/oxalica/nil)                              |
 | `pyright`                           | [pyright](https://github.com/microsoft/pyright)                                                        |
 | `rust-analyzer`                     | [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer)                                        |
-| `sourcekit-lsp`                     | [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)                                                |
-| `terraform-ls`                      | [terraform-ls](https://github.com/hashicorp/terraform-ls)                                              |
-| `typescript-language-server`        | [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server) |
-| `typescript`                        | [typescript](https://github.com/microsoft/TypeScript)                                                  |
 | `vscode-langservers-extracted`      | [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted)                |
 | `yaml-language-server`              | [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)                       |
-| `zls`                               | [zls](https://github.com/zigtools/zls)                                                                 |
 
 ### Formatters
 
@@ -63,12 +48,11 @@ These formatters ensure code consistency and style compliance by automatically f
 
 | Dependency Name  | Dependency URL                                             |
 |------------------|------------------------------------------------------------|
-| `alejandra`      | [alejandra](https://github.com/kirelagin/alejandra)        |
+| `alejandra`      | [alejandra](https://github.com/kamadorueda/alejandra)        |
 | `black`          | [black](https://github.com/psf/black)                      |
 | `gofumpt`        | [gofumpt](https://github.com/mvdan/gofumpt)                |
 | `golines`        | [golines](https://github.com/segmentio/golines)            |
 | `rustfmt`        | [rustfmt](https://github.com/rust-lang/rustfmt)            |
-| `terraform`      | [terraform](https://github.com/hashicorp/terraform)        |
 
 ## Plugins
 
@@ -145,7 +129,6 @@ Extra plugins that provide functionalities such as Git integration, status lines
 | `nvim-notify`                 | [nvim-notify](https://github.com/rcarriga/nvim-notify)                                |
 | `nvim-treesitter-context`     | [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) |
 | `nvim-web-devicons`           | [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)                  |
-| `omnisharp-extended-lsp-nvim` | [omnisharp-extended-lsp.nvim](https://github.com/Hoffs/omnisharp-extended-lsp.nvim)   |
 | `rainbow-delimiters-nvim`     | [rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim)         |
 | `trouble-nvim`                | [trouble.nvim](https://github.com/folke/trouble.nvim)                                 |
 
@@ -215,7 +198,6 @@ return require('packer').startup(function(use)
   use 'rcarriga/nvim-notify'
   use 'nvim-treesitter/nvim-treesitter-context'
   use 'kyazdani42/nvim-web-devicons'
-  use 'Hoffs/omnisharp-extended-lsp.nvim'
   use 'HiPhish/rainbow-delimiters.nvim'
   use 'folke/trouble.nvim'
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Extra plugins that provide functionalities such as Git integration, status lines
 | `comment-nvim`                | [comment.nvim](https://github.com/numToStr/Comment.nvim)                              |
 | `copilot-lua`                 | [copilot.lua](https://github.com/zbirenbaum/copilot.lua)                              |
 | `gitsigns-nvim`               | [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)                           |
+## TODO probably would be nice to add neogit/lazygit/fugitive
+see https://youtu.be/K-FKqXj8BAQ?si=JBKaGTZZo_w_oA-P
 | `lualine-nvim`                | [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)                          |
 | `noice-nvim`                  | [noice.nvim](https://github.com/folke/noice.nvim)                                     |
 | `nui-nvim`                    | [nui.nvim](https://github.com/MunifTanjim/nui.nvim)                                   |

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "copilotchat": {
       "flake": false,
       "locked": {
-        "lastModified": 1730583480,
-        "narHash": "sha256-YvqpR1pwyGKd+yp/I+q8b4eb62MpcfQazP9h9FDu/kA=",
+        "lastModified": 1731946461,
+        "narHash": "sha256-fMve12xmqUgPFetbjKfz3bNk6sAjUfaeFGW+/8bahMg=",
         "owner": "CopilotC-Nvim",
         "repo": "CopilotChat.nvim",
-        "rev": "041465aa7e1d557edad8bb8239667e0b3a87b969",
+        "rev": "ff17f9217e844a7ac7f771c70216020c703415ad",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "copilotchat": {
       "flake": false,
       "locked": {
-        "lastModified": 1727262716,
-        "narHash": "sha256-b78JSwWhbWRq0Thc9BNJIaziwSrb5Gzym8MXCn4v9bU=",
+        "lastModified": 1730583480,
+        "narHash": "sha256-YvqpR1pwyGKd+yp/I+q8b4eb62MpcfQazP9h9FDu/kA=",
         "owner": "CopilotC-Nvim",
         "repo": "CopilotChat.nvim",
-        "rev": "9333944fde3c65868818e245c73aa29eef826e9b",
+        "rev": "041465aa7e1d557edad8bb8239667e0b3a87b969",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729413321,
-        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {
@@ -53,14 +53,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "root": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -70,7 +70,9 @@ in rec {
     vimPlugins.trouble-nvim
     vimPlugins.which-key-nvim
     vimPlugins.undotree
+
     vimPlugins.obsidian-nvim
+    vimPlugins.nvim-cmp # required for obsidian (completion)
 
     # configuration
     TheAltF4Stream-nvim

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -42,7 +42,6 @@ in rec {
     vimPlugins.nvim-treesitter.withAllGrammars
     vimPlugins.rust-tools-nvim
     vimPlugins.vim-just
-    vimPlugins.vim-nickel
     vimPlugins.zig-vim
 
     # telescope

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -70,6 +70,7 @@ in rec {
     vimPlugins.trouble-nvim
     vimPlugins.which-key-nvim
     vimPlugins.undotree
+    vimPlugins.obsidian-nvim
 
     # configuration
     TheAltF4Stream-nvim

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -38,7 +38,6 @@ in rec {
     TheAltF4Stream-nvim = mkVimPlugin {inherit system;};
   in [
     # languages
-    vimPlugins.dhall-vim
     vimPlugins.nvim-lspconfig
     vimPlugins.nvim-treesitter.withAllGrammars
     vimPlugins.rust-tools-nvim
@@ -68,7 +67,6 @@ in rec {
     vimPlugins.nvim-notify
     vimPlugins.nvim-treesitter-context
     vimPlugins.nvim-web-devicons
-    vimPlugins.omnisharp-extended-lsp-nvim
     vimPlugins.rainbow-delimiters-nvim
     vimPlugins.trouble-nvim
 
@@ -77,7 +75,7 @@ in rec {
   ];
 
   mkExtraPackages = {system}: let
-    inherit (pkgs) nodePackages ocamlPackages python3Packages;
+    inherit (pkgs) nodePackages python3Packages;
     pkgs = import inputs.nixpkgs {
       inherit system;
       config.allowUnfree = true;
@@ -87,32 +85,20 @@ in rec {
     nodePackages.bash-language-server
     nodePackages.diagnostic-languageserver
     nodePackages.dockerfile-language-server-nodejs
-    nodePackages.typescript
-    nodePackages.typescript-language-server
     nodePackages.vscode-langservers-extracted
     nodePackages.yaml-language-server
-    ocamlPackages.ocaml-lsp
-    ocamlPackages.ocamlformat
-    pkgs.cuelsp
-    pkgs.dhall-lsp-server
     pkgs.gopls
     pkgs.jsonnet-language-server
     pkgs.lua-language-server
     pkgs.nil
-    pkgs.nls
-    pkgs.omnisharp-roslyn
-    pkgs.postgres-lsp
     pkgs.pyright
     pkgs.rust-analyzer
-    pkgs.terraform-ls
-    pkgs.zls
 
     # formatters
     pkgs.alejandra
     pkgs.gofumpt
     pkgs.golines
     pkgs.rustfmt
-    pkgs.terraform
     python3Packages.black
   ];
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -69,6 +69,7 @@ in rec {
     vimPlugins.rainbow-delimiters-nvim
     vimPlugins.trouble-nvim
     vimPlugins.which-key-nvim
+    vimPlugins.undotree
 
     # configuration
     TheAltF4Stream-nvim

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -91,7 +91,6 @@ in rec {
     nodePackages.dockerfile-language-server-nodejs
     nodePackages.vscode-langservers-extracted
     nodePackages.yaml-language-server
-    pkgs.gopls
     pkgs.jsonnet-language-server
     pkgs.lua-language-server
     pkgs.nil

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -68,6 +68,7 @@ in rec {
     vimPlugins.nvim-web-devicons
     vimPlugins.rainbow-delimiters-nvim
     vimPlugins.trouble-nvim
+    vimPlugins.which-key-nvim
 
     # configuration
     TheAltF4Stream-nvim

--- a/lua/TheAltF4Stream/floaterm.lua
+++ b/lua/TheAltF4Stream/floaterm.lua
@@ -1,12 +1,13 @@
 local function init()
     local options = { noremap = true, silent = true }
 
-    vim.keymap.set('n', '<leader>bb', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 btm<CR>', options)
+    -- vim.keymap.set('n', '<leader>bb', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 btm<CR>', options)
     vim.keymap.set('n', '<leader>k9', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 k9s<CR>', options)
-    vim.keymap.set('n', '<leader>ld', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 lazydocker<CR>', options)
-    vim.keymap.set('n', '<leader>lg', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 lazygit<CR>', options)
-    vim.keymap.set('n', '<leader>nn', '<CMD>FloatermNew --autoclose=2 --height=0.75 --width=0.75 nnn -Hde<CR>', options)
-    vim.keymap.set('n', '<leader>tt', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 zsh<CR>', options)
+    -- vim.keymap.set('n', '<leader>ld', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 lazydocker<CR>', options)
+    -- vim.keymap.set('n', '<leader>lg', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 lazygit<CR>', options)
+    -- vim.keymap.set('n', '<leader>nn', '<CMD>FloatermNew --autoclose=2 --height=0.75 --width=0.75 nnn -Hde<CR>', options)
+    vim.keymap.set('n', '<leader>tt', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 fish<CR>', options)
+asdoiokp
 end
 
 return {

--- a/lua/TheAltF4Stream/floaterm.lua
+++ b/lua/TheAltF4Stream/floaterm.lua
@@ -7,7 +7,6 @@ local function init()
     -- vim.keymap.set('n', '<leader>lg', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 lazygit<CR>', options)
     -- vim.keymap.set('n', '<leader>nn', '<CMD>FloatermNew --autoclose=2 --height=0.75 --width=0.75 nnn -Hde<CR>', options)
     vim.keymap.set('n', '<leader>tt', '<CMD>FloatermNew --autoclose=2 --height=0.9 --width=0.9 fish<CR>', options)
-asdoiokp
 end
 
 return {

--- a/lua/TheAltF4Stream/init.lua
+++ b/lua/TheAltF4Stream/init.lua
@@ -5,6 +5,7 @@ local function init()
     require 'TheAltF4Stream.telescope'.init()
     require 'TheAltF4Stream.floaterm'.init()
     require 'TheAltF4Stream.copilot'.init()
+    require 'TheAltF4Stream.obsidian'.init()
 end
 
 return {

--- a/lua/TheAltF4Stream/languages.lua
+++ b/lua/TheAltF4Stream/languages.lua
@@ -132,7 +132,6 @@ local function init()
                 },
             }
         },
-        nickel_ls = {},
         nil_ls = {
             settings = {
                 ['nil'] = {

--- a/lua/TheAltF4Stream/languages.lua
+++ b/lua/TheAltF4Stream/languages.lua
@@ -28,20 +28,20 @@ local function on_attach(client, buffer)
     -- Enable completion triggered by <c-x><c-o>
     vim.bo[buffer].omnifunc = 'v:lua.vim.lsp.omnifunc'
 
-    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
-    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
-    vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
+    -- vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
+    -- vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
+    -- vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
+    -- vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
+    -- vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
     vim.keymap.set('n', '<leader>wa', vim.lsp.buf.add_workspace_folder, opts)
     vim.keymap.set('n', '<leader>wr', vim.lsp.buf.remove_workspace_folder, opts)
     vim.keymap.set('n', '<leader>wl', function()
         print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
     end, opts)
-    vim.keymap.set('n', '<leader>D', vim.lsp.buf.type_definition, opts)
+    -- vim.keymap.set('n', '<leader>D', vim.lsp.buf.type_definition, opts)
     vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
     vim.keymap.set({ 'n', 'v' }, '<leader>ca', vim.lsp.buf.code_action, opts)
-    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
+    -- vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
     vim.keymap.set('n', '<leader>f', function() vim.lsp.buf.format { async = true } end, opts)
 
     if client.server_capabilities.documentHighlightProvider then

--- a/lua/TheAltF4Stream/languages.lua
+++ b/lua/TheAltF4Stream/languages.lua
@@ -1,6 +1,5 @@
 local copilot = require 'copilot'
 local lspconfig = require 'lspconfig'
-local omnisharp_extended = require 'omnisharp_extended'
 local rust_tools = require 'rust-tools'
 local treesitter = require 'nvim-treesitter.configs'
 local treesitter_context = require 'treesitter-context'
@@ -104,7 +103,6 @@ local function init()
                 },
             }
         },
-        dhall_lsp_server = {},
         dockerls = {},
         gopls = {
             settings = {
@@ -142,14 +140,6 @@ local function init()
                 },
             }
         },
-        ocamllsp = {},
-        omnisharp = {
-            cmd = { "omnisharp", "--languageserver", "--hostPID", tostring(vim.fn.getpid()) },
-            handlers = {
-                ["textDocument/definition"] = omnisharp_extended.handler,
-            },
-        },
-        postgres_lsp = {},
         pyright = {
             settings = {
                 python = {
@@ -161,7 +151,6 @@ local function init()
                 },
             },
         },
-        terraformls = {},
         ts_ls = {},
         yamlls = {
             settings = {
@@ -170,7 +159,6 @@ local function init()
                 },
             },
         },
-        zls = {},
     }
 
     -- Initialize servers

--- a/lua/TheAltF4Stream/languages.lua
+++ b/lua/TheAltF4Stream/languages.lua
@@ -104,13 +104,6 @@ local function init()
             }
         },
         dockerls = {},
-        gopls = {
-            settings = {
-                gopls = {
-                    gofumpt = true,
-                },
-            },
-        },
         html = {},
         jsonls = {},
         jsonnet_ls = {},

--- a/lua/TheAltF4Stream/obsidian.lua
+++ b/lua/TheAltF4Stream/obsidian.lua
@@ -1,0 +1,66 @@
+local function init()
+    require("obsidian").setup({
+      workspaces = {
+        {
+            name = "obsidian-vault",
+            path = "/home/strudelpi/Documents/obsidian-vault",
+          },
+      },
+      notes_subdir = "inbox",
+      new_notes_location = "notes_subdir",
+
+
+      disable_frontmatter = true,
+      templates = {
+          subdir = "templates",
+          date_format = "%Y-%m-%d",
+          time_format = "%H:%M:%S",
+      },
+      -- name new notes starting the ISO datetime and ending with note name
+      -- put them in the inbox subdir
+      -- note_id_func = function(title)
+      --   local suffix = ""
+      --   -- get current ISO datetime with -5 hour offset from UTC for EST
+      --   local current_datetime = os.date("!%Y-%m-%d-%H%M%S", os.time() - 5*3600)
+      --   if title ~= nil then
+      --     suffix = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
+      --   else
+      --     for _ = 1, 4 do
+      --       suffix = suffix .. string.char(math.random(65, 90))
+      --     end
+      --   end
+      --   return current_datetime .. "_" .. suffix
+      -- end,
+      -- key mappings, below are the defaults
+      mappings = {
+        -- overrides the 'gf' mapping to work on markdown/wiki links within your vault
+        ["gf"] = {
+          action = function()
+            return require("obsidian").util.gf_passthrough()
+          end,
+          opts = { noremap = false, expr = true, buffer = true },
+        },
+        -- toggle check-boxes
+        ["<leader>ti"] = {
+          action = function()
+            return require("obsidian").util.toggle_checkbox()
+          end,
+          opts = { buffer = true },
+        },
+      },
+      completion = {
+        nvim_cmp = true,
+        min_chars = 2,
+      },
+      ui = {
+        -- Disable some things below here because I set these manually for all Markdown files using treesitter
+        checkboxes = { },
+        bullets = {  },
+      },
+    })
+end
+
+return {
+    init = init,
+}
+

--- a/lua/TheAltF4Stream/telescope.lua
+++ b/lua/TheAltF4Stream/telescope.lua
@@ -36,10 +36,10 @@ local function init()
     vim.keymap.set('n', '<leader>fr', '<CMD>lua require("telescope.builtin").registers()<CR>', options)
 
     -- Language Servers
-    vim.keymap.set('n', '<leader>lsd', '<CMD>lua require("telescope.builtin").lsp_definitions{}<CR>', options)
-    vim.keymap.set('n', '<leader>lsi', '<CMD>lua require("telescope.builtin").lsp_implementations{}<CR>', options)
-    vim.keymap.set('n', '<leader>lsl', '<CMD>lua require("telescope.builtin").lsp_code_actions{}<CR>', options)
-    vim.keymap.set('n', '<leader>lst', '<CMD>lua require("telescope.builtin").lsp_type_definitions{}<CR>', options)
+    vim.keymap.set('n', 'gd', '<CMD>lua require("telescope.builtin").lsp_definitions{}<CR>', options)
+    vim.keymap.set('n', 'gr', '<CMD>lua require("telescope.builtin").lsp_references{}<CR>', options)
+    vim.keymap.set('n', 'gi', '<CMD>lua require("telescope.builtin").lsp_implementations{}<CR>', options)
+    vim.keymap.set('n', '<leader>D', '<CMD>lua require("telescope.builtin").lsp_type_definitions{}<CR>', options)
 
     -- Extensions
     vim.keymap.set('n', '<leader>fn', '<CMD>lua require("telescope").extensions.notify.notify()<CR>', options)

--- a/lua/TheAltF4Stream/vim.lua
+++ b/lua/TheAltF4Stream/vim.lua
@@ -1,5 +1,6 @@
 local function set_vim_g()
     vim.g.mapleader = " "
+    vim.g.maplocalleader = " "
 end
 
 local function set_vim_o()
@@ -38,16 +39,37 @@ end
 
 local function set_vim_opt()
     vim.opt.list = true
-    vim.opt.listchars:append "eol:↴"
+    -- vim.opt.listchars:append "eol:↴"
+    vim.opt.ignorecase = true
+    vim.opt.smartcase = true
+    vim.opt.undofile = true
+    vim.opt.signcolumn = 'yes'
+    vim.opt.updatetime = 250
+    vim.opt.listchars = { tab = '» ', trail = '·', nbsp = '␣' }
+    vim.opt.scrolloff = 10
 end
 
 local function set_vim_keymaps()
     local options = { noremap = false, silent = true }
-
+    -- moving focus panel
     vim.keymap.set('n', '<leader>h', '<CMD>wincmd h<CR>', options)
     vim.keymap.set('n', '<leader>j', '<CMD>wincmd j<CR>', options)
     vim.keymap.set('n', '<leader>k', '<CMD>wincmd k<CR>', options)
     vim.keymap.set('n', '<leader>l', '<CMD>wincmd l<CR>', options)
+    -- Clear highlights on search when pressing <Esc> in normal mode
+    --  See `:help hlsearch`
+    vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
+    -- Highlight when yanking (copying) text
+    --  Try it with `yap` in normal mode
+    --  See `:help vim.highlight.on_yank()`
+    vim.api.nvim_create_autocmd('TextYankPost', {
+        desc = 'Highlight when yanking (copying) text',
+        group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
+        callback = function()
+            vim.highlight.on_yank()
+    end,
+    })
+
 end
 
 local function init()

--- a/lua/TheAltF4Stream/vim.lua
+++ b/lua/TheAltF4Stream/vim.lua
@@ -69,6 +69,7 @@ local function set_vim_keymaps()
             vim.highlight.on_yank()
     end,
     })
+    vim.keymap.set('n', '<leader><F5>', vim.cmd.UndotreeToggle)
 
 end
 


### PR DESCRIPTION
Currently due to a rename you would get this:
```
nix shell .#neovim
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'neovim-0.10.2'
         whose name attribute is located at /nix/store/dyzl40h25l04565n90psbhzgnc5vp2xr-source/pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'postBuild' of derivation 'neovim-0.10.2'

         at /nix/store/dyzl40h25l04565n90psbhzgnc5vp2xr-source/pkgs/applications/editors/neovim/wrapper.nix:158:7:

          157|       # extra actions upon
          158|       postBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
             |       ^
          159|         rm $out/share/applications/nvim.desktop

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 'utillinux' has been renamed to/replaced by 'util-linux'
```

been fixed a while, so flake update is all you need