### PR TITLE
feat: add notion.nvim plugin integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,30 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750365781,
-        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {
@@ -16,9 +34,60 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "notion-nvim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1751171755,
+        "narHash": "sha256-9l02X3678mXfjX3lKU9SMMF/LXLpIVJLqrz9FJMH7Gs=",
+        "owner": "ALT-F4-LLC",
+        "repo": "notion.nvim",
+        "rev": "66aefe122da43ef3ae9477715a11f3c3b7c45fde",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ALT-F4-LLC",
+        "repo": "notion.nvim",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "notion-nvim": "notion-nvim"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,15 @@
 {
   description = "Neovim configuration for TheAltF4Stream.";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    notion-nvim.url = "github:ALT-F4-LLC/notion.nvim";
+  };
 
   outputs = {
     self,
     nixpkgs,
+    notion-nvim,
   }: let
     forAllSystems = nixpkgs.lib.genAttrs ["aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux"];
   in {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,6 +4,7 @@ in rec {
   mkVimPlugin = {system}: let
     inherit (pkgs) vimUtils;
     inherit (vimUtils) buildVimPlugin;
+    notion-nvim = inputs.notion-nvim.packages.${system}.default;
     pkgs = legacyPackages.${system};
   in
     buildVimPlugin {
@@ -33,6 +34,7 @@ in rec {
         gitsigns-nvim
         lualine-nvim
         noice-nvim
+        notion-nvim
         nvim-colorizer-lua
         nvim-notify
         nvim-treesitter-context

--- a/lua/TheAltF4Stream/init.lua
+++ b/lua/TheAltF4Stream/init.lua
@@ -5,6 +5,7 @@ local function init()
     require 'TheAltF4Stream.telescope'.init()
     require 'TheAltF4Stream.floaterm'.init()
     require 'TheAltF4Stream.assistant'.init()
+    require 'TheAltF4Stream.notion'.init()
 end
 
 return {

--- a/lua/TheAltF4Stream/notion.lua
+++ b/lua/TheAltF4Stream/notion.lua
@@ -1,0 +1,13 @@
+local notion = require 'notion'
+
+local function init()
+    notion.setup({
+        notion_token_cmd = { 'doppler', 'secrets', 'get', '--plain', 'NOTION_TOKEN' },
+        database_id = '21f1a19994538010a449f9026b0e8552',
+        debug = true
+    })
+end
+
+return {
+    init = init,
+}


### PR DESCRIPTION
## Summary
- Added notion.nvim plugin to the Neovim configuration
- Integrated plugin with Nix flake system using notion-nvim input
- Configured plugin with Doppler secrets integration for Notion API token
- Added plugin initialization to main configuration

## Changes Made
- Updated `flake.nix` to include notion-nvim input
- Modified `lib/default.nix` to build and include the notion-nvim plugin
- Added `lua/TheAltF4Stream/notion.lua` configuration file
- Updated main init to load notion configuration