### PR TITLE
chore(deps): update flake dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1751171755,
-        "narHash": "sha256-9l02X3678mXfjX3lKU9SMMF/LXLpIVJLqrz9FJMH7Gs=",
+        "lastModified": 1751488040,
+        "narHash": "sha256-gdYvAUtEx+yKYu1KVzUjRF1LbhYQNiqtWeJi+Xqu+fY=",
         "owner": "ALT-F4-LLC",
         "repo": "notion.nvim",
-        "rev": "66aefe122da43ef3ae9477715a11f3c3b7c45fde",
+        "rev": "5eda0348157f02049402fe01f0e34054b88f6ee8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
• Updated nixpkgs from 2025-06-27 to 2025-06-30 for latest system packages and bug fixes
• Updated notion-nvim from 2025-06-29 to 2025-07-02 for latest plugin improvements

## Test plan
- [x] Run `nix flake check` to validate flake configuration
- [x] Test neovim configuration with `nix run .#nvim`
- [x] Verify all plugins load correctly
- [x] Confirm notion.nvim functionality works as expected

🤖 Generated with [opencode](https://opencode.ai)